### PR TITLE
Fix squeezed time slots on desktop

### DIFF
--- a/resources/views/public/home/booking.blade.php
+++ b/resources/views/public/home/booking.blade.php
@@ -370,6 +370,10 @@
       cursor: pointer;
       transition: all 0.3s ease;
       font-weight: 500;
+      float: none !important;
+      width: auto !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
     }
 
     .time-slot li:hover {


### PR DESCRIPTION
## Summary
- override conflicting CSS from `custom.css`
- ensure time slot items use grid layout without float/width forcing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68549bbce184832d8de22357838181dc