### PR TITLE
Fix: remove insecure deploy route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -147,17 +147,5 @@ Route::get('/test', function () {
     return Inertia::render('Test');
 });
 
-Route::post('/deploy', function () {
-    $secret = "123"; // Use a mesma que foi usada no webhook do GitHub
-    $signature = hash_hmac('sha256', file_get_contents("php://input"), $secret);
-
-    if (hash_equals($signature, $_SERVER['HTTP_X_HUB_SIGNATURE'])) {
-        // Se a assinatura do webhook for válida, puxe as atualizações mais recentes feito aqui
-        shell_exec('cd .. && sudo git reset --hard HEAD && sudo git pull');
-    }
-
-    return ['status' => 'success'];
-});
-
 Route::get('/treino', [AgendaController::class, 'treino'])->name('treino');
 Route::get('/logs', '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');


### PR DESCRIPTION
## Summary
- remove insecure `/deploy` route

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4c6270c4832d97cc4c2f0ebbded5