### PR TITLE
Add basic analytics dashboard

### DIFF
--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\AnalyticsEvent;
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+
+class AnalyticsController extends Controller
+{
+    public function recordEvent(Request $request)
+    {
+        $data = $request->validate([
+            'empresa_id' => 'nullable|integer',
+            'event_type' => 'required|string',
+            'value' => 'nullable|numeric',
+        ]);
+
+        AnalyticsEvent::create($data);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function dashboard(Request $request)
+    {
+        if (!auth()->check() || !auth()->user()->isAdmin) {
+            abort(403);
+        }
+
+        $range = $request->get('range', '7days');
+
+        $start = match ($range) {
+            'today' => Carbon::today(),
+            'month' => Carbon::now()->startOfMonth(),
+            default => Carbon::now()->subDays(6),
+        };
+
+        $empresaId = auth()->user()->empresa->id ?? null;
+
+        $events = AnalyticsEvent::where('created_at', '>=', $start)
+            ->when($empresaId, fn($q) => $q->where('empresa_id', $empresaId))
+            ->get()
+            ->groupBy(fn($e) => $e->created_at->format('Y-m-d'));
+
+        $labels = [];
+        $visits = [];
+        $whatsapp = [];
+        $load = [];
+
+        foreach (CarbonPeriod::create($start, Carbon::today()) as $date) {
+            $day = $date->format('Y-m-d');
+            $labels[] = $day;
+            $dayEvents = $events[$day] ?? collect();
+            $visits[] = $dayEvents->where('event_type', 'visit')->count();
+            $whatsapp[] = $dayEvents->where('event_type', 'whatsapp_click')->count();
+            $load[] = round($dayEvents->where('event_type', 'page_load_time')->avg('value'), 2);
+        }
+
+        $chartData = [
+            'labels' => $labels,
+            'visits' => $visits,
+            'whatsapp' => $whatsapp,
+            'load' => $load,
+        ];
+
+        return view('analytics.dashboard', compact('chartData', 'range'));
+    }
+}

--- a/app/Models/AnalyticsEvent.php
+++ b/app/Models/AnalyticsEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AnalyticsEvent extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'empresa_id',
+        'event_type',
+        'value',
+    ];
+
+    public function empresa()
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+}

--- a/database/migrations/2025_07_01_000000_create_analytics_events_table.php
+++ b/database/migrations/2025_07_01_000000_create_analytics_events_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('analytics_events', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('empresa_id')->nullable();
+            $table->string('event_type');
+            $table->float('value')->nullable();
+            $table->timestamps();
+
+            $table->foreign('empresa_id')->references('id')->on('empresa')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('analytics_events');
+    }
+};

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -1,0 +1,26 @@
+(function(){
+    function send(type, value){
+        var empresaMeta = document.querySelector('meta[name="empresa-id"]');
+        var empresaId = empresaMeta ? empresaMeta.content : null;
+
+        fetch('/analytics/event', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+            },
+            body: JSON.stringify({event_type: type, value: value, empresa_id: empresaId})
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function(){
+        if(window.performance && performance.timing){
+            var time = performance.timing.domContentLoadedEventEnd - performance.timing.navigationStart;
+            send('page_load_time', time);
+        }
+        send('visit');
+        document.querySelectorAll('[data-whatsapp-button]').forEach(function(btn){
+            btn.addEventListener('click', function(){ send('whatsapp_click'); });
+        });
+    });
+})();

--- a/resources/views/analytics/dashboard.blade.php
+++ b/resources/views/analytics/dashboard.blade.php
@@ -1,0 +1,47 @@
+<x-admin.layout title="Relatórios">
+    <div class="page-wrapper">
+        <div class="content container-fluid">
+            <h3 class="mb-4">Relatórios do Site</h3>
+
+            <form method="GET" class="mb-4">
+                <select name="range" class="form-select" style="max-width:200px" onchange="this.form.submit()">
+                    <option value="today" {{ request('range')=='today' ? 'selected' : '' }}>Hoje</option>
+                    <option value="7days" {{ request('range')=='7days' ? 'selected' : '' }}>Últimos 7 dias</option>
+                    <option value="month" {{ request('range')=='month' ? 'selected' : '' }}>Mês atual</option>
+                </select>
+            </form>
+
+            <div class="row">
+                <div class="col-md-4">
+                    <canvas id="visitsChart"></canvas>
+                </div>
+                <div class="col-md-4">
+                    <canvas id="whatsappChart"></canvas>
+                </div>
+                <div class="col-md-4">
+                    <canvas id="loadChart"></canvas>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const data = @json($chartData);
+
+        new Chart(document.getElementById('visitsChart'), {
+            type: 'bar',
+            data: { labels: data.labels, datasets: [{ label: 'Visitas', data: data.visits, backgroundColor: '#0d6efd' }] }
+        });
+
+        new Chart(document.getElementById('whatsappChart'), {
+            type: 'bar',
+            data: { labels: data.labels, datasets: [{ label: 'Cliques WhatsApp', data: data.whatsapp, backgroundColor: '#198754' }] }
+        });
+
+        new Chart(document.getElementById('loadChart'), {
+            type: 'line',
+            data: { labels: data.labels, datasets: [{ label: 'Tempo de Carregamento (ms)', data: data.load, borderColor: '#dc3545' }] }
+        });
+    </script>
+</x-admin.layout>

--- a/resources/views/components/public/header.blade.php
+++ b/resources/views/components/public/header.blade.php
@@ -5,6 +5,10 @@
     <meta charset="utf-8">
     <title>{{ $title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    @if(!empty($empresaId))
+        <meta name="empresa-id" content="{{ $empresaId }}">
+    @endif
 
     <!-- Favicons -->
     <link href="{{ asset('template/assets/img/favicon.png') }}" rel="icon">
@@ -102,6 +106,13 @@
                                         </a>
                                     </li>
                                 @endif
+                                @if (auth()->user()->isAdmin)
+                                    <li class="nav-item">
+                                        <a href="{{ route('admin.analytics.dashboard') }}" class="btn btn-outline-secondary">
+                                            <i class="fas fa-chart-bar"></i> Relatórios
+                                        </a>
+                                    </li>
+                                @endif
 
                                 <li class="nav-item ms-2" style="color:#000;">
                                     <a href="{{ route('user.logout') }}" class="btn btn-outline-danger"
@@ -137,6 +148,7 @@
     <!-- Scripts -->
 
     <script src="{{ asset('template/assets/js/bootstrap.bundle.min.js') }}"></script>
+    <script src="{{ asset('js/analytics.js') }}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Validação de confirmação de senha

--- a/resources/views/components/public/layout.blade.php
+++ b/resources/views/components/public/layout.blade.php
@@ -1,3 +1,3 @@
-<x-public.header :title="$title"/>
+<x-public.header :title="$title" :empresa-id="$empresaId ?? null"/>
     {{$slot}}     
 <x-public.footer/>

--- a/resources/views/public/home/show.blade.php
+++ b/resources/views/public/home/show.blade.php
@@ -1,4 +1,4 @@
-<x-public.layout title="HOME">
+<x-public.layout title="HOME" :empresa-id="$model->id">
    
     <!-- Breadcrumb -->
 		<x-home.breadcrumb title="{{$model->nome}}"  :model="$model" />

--- a/resources/views/site/publico.blade.php
+++ b/resources/views/site/publico.blade.php
@@ -4,6 +4,8 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{ $site->titulo }} - {{ $site->descricao ?? 'Site oficial' }}</title>
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+        <meta name="empresa-id" content="{{ $site->empresa_id }}">
     
         {{-- Favicon opcional --}}
         @if(!empty($site->favicon))
@@ -505,5 +507,6 @@ $corSecundaria = $site->cores['secundaria'] ?? '#38b2ac';
             });
         });
     </script>
+    <script src="{{ asset('js/analytics.js') }}"></script>
 </body>
 </html>

--- a/routes/web_private.php
+++ b/routes/web_private.php
@@ -231,4 +231,8 @@ Route::group(['prefix' => '/manager'], function () {
     // Route::get('/', [AdminController::class, 'dashboard'])->name('admin.dashboard');
 });
 
-Route::prefix('admin')->middleware('auth')->group(function () {});
+Route::post('/analytics/event', [\App\Http\Controllers\AnalyticsController::class, 'recordEvent'])->name('analytics.event');
+
+Route::prefix('admin')->middleware('auth')->group(function () {
+    Route::get('/relatorios', [\App\Http\Controllers\AnalyticsController::class, 'dashboard'])->name('admin.analytics.dashboard');
+});


### PR DESCRIPTION
## Summary
- add migrations and model for analytics events
- record events and display dashboard
- add script to capture visit, click, and load time data
- show `Relatórios` menu when admin logged in
- wire up routes for analytics
- track analytics per empresa

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c43daeb18832d95c1f0fffb803b23