### PR TITLE
Add site menu item to Escola sidebar

### DIFF
--- a/resources/views/components/admin/sidebarescola.blade.php
+++ b/resources/views/components/admin/sidebarescola.blade.php
@@ -41,6 +41,7 @@
                                 <li><a href="{{ route('admin.site.configuracoes') }}">Configurações do Site</a></li>
                                 <li><a href="{{ route('admin.site.servicos.index') }}">Serviços</a></li>
                                 <li><a href="{{ route('admin.site.depoimentos.index') }}">Depoimentos</a></li>
+                                <li><a href="{{ route('admin.site.menu.index') }}">Menu</a></li>
                                 <li><a href="{{ route('admin.site.contatos.index') }}">Contatos</a></li>
                                 <li><a href="{{ route('admin.site.dominios.index') }}">Domínios e SSL</a></li>
                             </ul>


### PR DESCRIPTION
## Summary
- add new Menu item in Site submenu of sidebar

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c61fb331c832d888c0512023e5140