### PR TITLE
Refactor OpenAI controller to use configurable service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,4 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 # OpenAI
 OPENAI_API_KEY=
+OPENAI_API_URL=https://api.openai.com/v1/chat/completions

--- a/app/Http/Controllers/OpenAIController.php
+++ b/app/Http/Controllers/OpenAIController.php
@@ -3,24 +3,19 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Http;
+use App\Services\OpenAIService;
 
 class OpenAIController extends Controller
 {
-    public function testConnection(Request $request)
+    public function testConnection(Request $request, OpenAIService $openAIService)
     {
-        $apiKey = env('OPENAI_API_KEY');
-        if (!$apiKey) {
-            return response()->json(['error' => 'OpenAI API key not configured'], 500);
-        }
-
-        $response = Http::withToken($apiKey)
-            ->post('https://api.openai.com/v1/chat/completions', [
-                'model' => 'gpt-3.5-turbo',
-                'messages' => [
-                    ['role' => 'user', 'content' => 'Diga olá'],
-                ],
+        try {
+            $response = $openAIService->chat([
+                ['role' => 'user', 'content' => 'Diga olá'],
             ]);
+        } catch (\RuntimeException $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
 
         if ($response->successful()) {
             return response()->json($response->json());

--- a/app/Services/OpenAIService.php
+++ b/app/Services/OpenAIService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class OpenAIService
+{
+    protected string $apiUrl;
+    protected ?string $apiKey;
+
+    public function __construct()
+    {
+        $this->apiUrl = config('openai.api_url');
+        $this->apiKey = env('OPENAI_API_KEY');
+    }
+
+    public function chat(array $messages, string $model = 'gpt-3.5-turbo')
+    {
+        if (!$this->apiKey) {
+            throw new \RuntimeException('OpenAI API key not configured');
+        }
+
+        return Http::withToken($this->apiKey)->post($this->apiUrl, [
+            'model' => $model,
+            'messages' => $messages,
+        ]);
+    }
+}

--- a/config/openai.php
+++ b/config/openai.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'api_url' => env('OPENAI_API_URL', 'https://api.openai.com/v1/chat/completions'),
+];


### PR DESCRIPTION
## Summary
- create OpenAI service to encapsulate API requests
- read API endpoint from `config/openai.php`
- configure `.env.example` with `OPENAI_API_URL`
- refactor `OpenAIController` to use the new service

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ef3d87b48832d89f68d877b6f014e