### PR TITLE
Use form request for Asaas client creation

### DIFF
--- a/app/Http/Controllers/Api/AsaasController.php
+++ b/app/Http/Controllers/Api/AsaasController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Professor;
 use Illuminate\Http\Request;
+use App\Http\Requests\CreateClientRequest;
 use App\Services\AsaasService;
 
 class AsaasController extends Controller
@@ -17,27 +18,9 @@ class AsaasController extends Controller
         $this->baseUri = env('ASAAS_ENV') == 'production' ? env('ASAAS_URL') : env('ASAAS_SANDBOX_URL');
     }
 
-    public function createClient(Request $request)
+    public function createClient(CreateClientRequest $request)
     {
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
-            'email' => 'required|email',
-            'cpfCnpj' => 'required|string|max:14',
-            'phone' => 'nullable|string',
-            'mobilePhone' => 'required|string',
-            'address' => 'required|string',
-            'addressNumber' => 'required|string',
-            'complement' => 'nullable|string',
-            'province' => 'required|string',
-            'postalCode' => 'required|string',
-            'externalReference' => 'nullable|string',
-            'notificationDisabled' => 'boolean',
-            'additionalEmails' => 'nullable|string',
-            'municipalInscription' => 'nullable|string',
-            'stateInscription' => 'nullable|string',
-            'observations' => 'nullable|string',
-            'groupName' => 'nullable|string',
-        ]);
+        $validated = $request->validated();
 
         $response = $this->asaasService->criarClienteAsaas($validated);
 

--- a/app/Http/Requests/CreateClientRequest.php
+++ b/app/Http/Requests/CreateClientRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateClientRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+            'cpfCnpj' => 'required|string|max:14',
+            'phone' => 'nullable|string',
+            'mobilePhone' => 'required|string',
+            'address' => 'required|string',
+            'addressNumber' => 'required|string',
+            'complement' => 'nullable|string',
+            'province' => 'required|string',
+            'postalCode' => 'required|string',
+            'externalReference' => 'nullable|string',
+            'notificationDisabled' => 'boolean',
+            'additionalEmails' => 'nullable|string',
+            'municipalInscription' => 'nullable|string',
+            'stateInscription' => 'nullable|string',
+            'observations' => 'nullable|string',
+            'groupName' => 'nullable|string',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add `CreateClientRequest` with validation rules for Asaas clients
- use `CreateClientRequest` in `AsaasController` to validate data

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686479613484832dbaf14b17a2eb39d5